### PR TITLE
Migrate CI to testitem-workflow v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/juliaci.yml
+++ b/.github/workflows/juliaci.yml
@@ -1,25 +1,19 @@
 name: Julia CI
 
 on:
-  push: {branches: [main, master]}
-  pull_request: {types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]}
+  push: {branches: [main,master]}
+  pull_request: {types: [opened,synchronize,reopened,ready_for_review,converted_to_draft]}
   issue_comment: {types: [created]}
-  schedule: [{cron: '0 0 * * *'}]
-  workflow_dispatch:
-    inputs:
-      feature:
-        type: choice
-        description: What to run
-        options: [CompatHelper, DocDeploy, LintAndTest, TagBot]
+  workflow_dispatch: {inputs: {feature: {type: choice, description: What to run, options: [DocDeploy,LintAndTest,TagBot]}}}
 
 jobs:
   julia-ci:
-    uses: julia-testitems/testitem-workflow/.github/workflows/juliaci.yml@v1
+    uses: julia-testitems/testitem-workflow/.github/workflows/juliaci.yml@v2
     with:
-        include-linux-x86: false
-        include-windows-x86: false
-        github_job_prep_script: test/github_job_prep.jl
-        env: '{"DATADEPS_ALWAYS_ACCEPT": ":true"}'
+      include-linux-x86: false
+      include-windows-x86: false
+      github_job_prep_script: test/github_job_prep.jl
+      env: '{"DATADEPS_ALWAYS_ACCEPT": ":true"}'
     permissions: write-all
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Migrates this repository to testitem-workflow v2.

- Bump the reusable workflow to `@v2`
- Drop the `schedule` trigger (v2 removes the `compat-helper` job; a cron in a
  public repo also gets the entire workflow file auto-disabled after 60 days of
  inactivity, silently stopping lint, tests, doc deploys and TagBot)
- Drop `CompatHelper` from the `workflow_dispatch` options
- Normalize the `pull_request` types to the v2 template so draft-PR overrides work
- Add `.github/dependabot.yml` (julia + github-actions, root only) to take over
  dependency updates from CompatHelper

Existing workflow options are unchanged.